### PR TITLE
Add black, isort, flake8, mypy, py.typed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+SRC = $(wildcard *.py) $(shell find src tests -type f -name '*.py')
+
+format:
+	black --line-length 110 $(SRC)
+	isort --profile black $(SRC)
+	flake8 --max-line-length=110 --ignore=E203,W503 --select=F,N $(SRC)
+	mypy $(SRC)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,5 +25,20 @@ dependencies = [
     "pydantic"
 ]
 
+[project.optional-dependencies]
+dev = [
+    "black",
+    "isort",
+    "flake8",
+    "mypy",
+    "types-requests",
+    "pytest"
+]
+
+[tool.setuptools.package-data]
+"flask_ml" = ["py.typed"]
+[tool.setuptools.packages.find]
+where = ["src"]
+
 [project.urls]
 Homepage = "https://github.com/UMass-Rescue/Flask-ML"

--- a/server_example.py
+++ b/server_example.py
@@ -46,18 +46,18 @@ def process_text(inputs: list[TextInput], parameters: dict):
 @server.route("/randomsentimentanalysis", DataTypes.TEXT)
 def sentiment_analysis(inputs: list[TextInput], parameters: dict):
     results = sentiment_model.predict(inputs)
-    results = [TextResult(text=res["text"], result=res["sentiment"]) for res in results]
-    response = ResponseModel(results=results)
+    text_results = [TextResult(text=res["text"], result=res["sentiment"]) for res in results]
+    response = ResponseModel(results=text_results)
     return response.get_response()
 
 
 @server.route("/imagestyletransfer", DataTypes.IMAGE)
 def image_style_transfer(inputs: list[FileInput], parameters: dict):
     results = image_style_transfer_model.predict(inputs)
-    results = [
+    image_results = [
         ImageResult(file_path=res["file_path"], result=res["result"]) for res in results
     ]
-    response = ResponseModel(results=results)
+    response = ResponseModel(results=image_results)
     return response.get_response()
 
 

--- a/src/flask_ml/flask_ml_client/MLClient.py
+++ b/src/flask_ml/flask_ml_client/MLClient.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import requests
 
 from flask_ml.flask_ml_server.models import (ErrorResponseModel, RequestModel,
@@ -28,7 +30,7 @@ class MLClient:
 
     def request(
         self, inputs: list[dict], data_type: str, parameters: dict = {}
-    ) -> list[dict]:
+    ) -> dict[str, Any] | list[dict]:
         """
         Sends a request to the server.
         inputs : list - the list of dictionaries containing the data to be sent to the server
@@ -36,7 +38,7 @@ class MLClient:
         parameters : dict - the parameters to be sent to the server
         """
         request_model = RequestModel(
-            inputs=inputs, data_type=data_type, parameters=parameters
+            inputs=inputs, data_type=data_type, parameters=parameters # type: ignore
         )
         response = requests.post(
             self.url,
@@ -46,7 +48,7 @@ class MLClient:
             return ErrorResponseModel(
                 status=f"Unknown error. status_code={str(response.status_code)}",
                 errors=[{"msg": UNKNOWN_ERROR}],
-            ).dict()
+            ).model_dump()
         if response.status_code != 200:
             return ErrorResponseModel(**response.json()).model_dump()
         response_model = ResponseModel(**response.json())

--- a/src/flask_ml/flask_ml_client/__init__.py
+++ b/src/flask_ml/flask_ml_client/__init__.py
@@ -1,1 +1,4 @@
+# mypy: ignore-errors
 from .MLClient import MLClient
+
+__all__ = ["MLClient"] # for flake8 unused import error

--- a/src/flask_ml/flask_ml_server/__init__.py
+++ b/src/flask_ml/flask_ml_server/__init__.py
@@ -1,1 +1,3 @@
 from .MLServer import MLServer
+
+__all__ = ["MLServer"] # for flake8 unused import error

--- a/src/flask_ml/flask_ml_server/models.py
+++ b/src/flask_ml/flask_ml_server/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Sequence, Union
 
 from flask import Response
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -130,7 +130,7 @@ class ResponseModel(BaseModel):
         description="The status of the operation, e.g., 'SUCCESS'",
         min_length=1,
     )
-    results: List[Union[TextResult, ImageResult, AudioResult, VideoResult]] = Field(
+    results: Sequence[Union[TextResult, ImageResult, AudioResult, VideoResult]] = Field(
         ...,
         description="List of results, each either a file or text with its result",
         min_length=1,


### PR DESCRIPTION
Hi, I added some minor improvements. If you like them, you can choose to accept.

1. Adds a dev dependencies section to pyproject.toml

They can be installed using
```bash
pip install -e '.[dev]'
```

2. Adds an empty `py.typed` file to the root package

This advertises to package installers that this package is typed. This prevents mypy giving this error to package users:

```error
error: Skipping analyzing "flask_ml.flask_ml_server.models": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```

3. Adds a Makefile that runs black, isort, flake8 and mypy

The Makefile can be simply run using:

```bash
make
```

black, isort, flake8 has not been applied in this PR to keep the diff short.