### PR TITLE
Schema support and pydantic response types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "flask_ml"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
   { name="Prasanna Lakkur Subramanyam", email="psubramanyam@umass.edu" },
 ]

--- a/server_example.py
+++ b/server_example.py
@@ -1,8 +1,12 @@
 from flask_ml.flask_ml_server import MLServer
 from flask_ml.flask_ml_server.constants import DataTypes
-from flask_ml.flask_ml_server.models import (FileInput, ImageResult,
-                                             ResponseModel, TextInput,
-                                             TextResult)
+from flask_ml.flask_ml_server.models import (
+    FileInput,
+    ImageResult,
+    ResponseModel,
+    TextInput,
+    TextResult,
+)
 
 
 # Create a dummy ML model

--- a/server_example.py
+++ b/server_example.py
@@ -6,7 +6,10 @@ from flask_ml.flask_ml_server.models import (
     ResponseModel,
     TextInput,
     TextResult,
+    BatchImageResult,
+    BatchTextResult,
 )
+from typing import List
 
 
 # Create a dummy ML model
@@ -42,31 +45,31 @@ server = MLServer(__name__)
 
 # Create an endpoint
 @server.route("/dummymodel", DataTypes.TEXT)
-def process_text(inputs: list[TextInput], parameters: dict):
+def process_text(inputs: List[TextInput], parameters: dict) -> BatchTextResult:
     results = model.predict(inputs)
-    results = [TextResult(text=e.text, result=r) for e, r in zip(inputs, results)]
-    response = ResponseModel(results=results)
-    return response.get_response()
+    results = [TextResult(id=e.text, result=r) for e, r in zip(inputs, results)]
+    response = BatchTextResult(results=results)
+    return response
 
 
 @server.route("/randomsentimentanalysis", DataTypes.TEXT)
-def sentiment_analysis(inputs: list[TextInput], parameters: dict):
+def sentiment_analysis(inputs: List[TextInput], parameters: dict):
     results = sentiment_model.predict(inputs)
     text_results = [
-        TextResult(text=res["text"], result=res["sentiment"]) for res in results
+        TextResult(id=res["text"], result=res["sentiment"]) for res in results
     ]
-    response = ResponseModel(results=text_results)
-    return response.get_response()
+    response = BatchTextResult(results=text_results)
+    return response
 
 
 @server.route("/imagestyletransfer", DataTypes.IMAGE)
-def image_style_transfer(inputs: list[FileInput], parameters: dict):
+def image_style_transfer(inputs: List[FileInput], parameters: dict) -> BatchImageResult:
     results = image_style_transfer_model.predict(inputs)
     image_results = [
-        ImageResult(file_path=res["file_path"], result=res["result"]) for res in results
+        ImageResult(id=res["file_path"], result=res["result"]) for res in results
     ]
-    response = ResponseModel(results=image_results)
-    return response.get_response()
+    response = BatchImageResult(results=image_results)
+    return response
 
 
 # Run the server (optional. You can also run the server using the command line)

--- a/server_example.py
+++ b/server_example.py
@@ -1,15 +1,11 @@
+from typing import List
+
 from flask_ml.flask_ml_server import MLServer
 from flask_ml.flask_ml_server.constants import DataTypes
-from flask_ml.flask_ml_server.models import (
-    FileInput,
-    ImageResult,
-    ResponseModel,
-    TextInput,
-    TextResult,
-    BatchImageResult,
-    BatchTextResult,
-)
-from typing import List
+from flask_ml.flask_ml_server.models import (BatchImageResult, BatchTextResult,
+                                             FileInput, ImageResult,
+                                             ResponseModel, TextInput,
+                                             TextResult)
 
 
 # Create a dummy ML model

--- a/server_example.py
+++ b/server_example.py
@@ -1,12 +1,8 @@
 from flask_ml.flask_ml_server import MLServer
 from flask_ml.flask_ml_server.constants import DataTypes
-from flask_ml.flask_ml_server.models import (
-    FileInput,
-    ImageResult,
-    ResponseModel,
-    TextInput,
-    TextResult,
-)
+from flask_ml.flask_ml_server.models import (FileInput, ImageResult,
+                                             ResponseModel, TextInput,
+                                             TextResult)
 
 
 # Create a dummy ML model
@@ -25,7 +21,10 @@ class SentimentModel:
 
 class ImageStyleTransferModel:
     def predict(self, data: list[FileInput]) -> list[dict]:
-        return [{"file_path": f.file_path, "result": f"stylized_image_{i}.jpg"} for i, f in enumerate(data)]
+        return [
+            {"file_path": f.file_path, "result": f"stylized_image_{i}.jpg"}
+            for i, f in enumerate(data)
+        ]
 
 
 # create an instance of the model
@@ -49,7 +48,9 @@ def process_text(inputs: list[TextInput], parameters: dict):
 @server.route("/randomsentimentanalysis", DataTypes.TEXT)
 def sentiment_analysis(inputs: list[TextInput], parameters: dict):
     results = sentiment_model.predict(inputs)
-    text_results = [TextResult(text=res["text"], result=res["sentiment"]) for res in results]
+    text_results = [
+        TextResult(text=res["text"], result=res["sentiment"]) for res in results
+    ]
     response = ResponseModel(results=text_results)
     return response.get_response()
 
@@ -57,7 +58,9 @@ def sentiment_analysis(inputs: list[TextInput], parameters: dict):
 @server.route("/imagestyletransfer", DataTypes.IMAGE)
 def image_style_transfer(inputs: list[FileInput], parameters: dict):
     results = image_style_transfer_model.predict(inputs)
-    image_results = [ImageResult(file_path=res["file_path"], result=res["result"]) for res in results]
+    image_results = [
+        ImageResult(file_path=res["file_path"], result=res["result"]) for res in results
+    ]
     response = ResponseModel(results=image_results)
     return response.get_response()
 

--- a/src/flask_ml/flask_ml_client/MLClient.py
+++ b/src/flask_ml/flask_ml_client/MLClient.py
@@ -2,11 +2,8 @@ from typing import Any, Union
 
 import requests
 
-from flask_ml.flask_ml_server.models import (
-    ErrorResponseModel,
-    RequestModel,
-    ResponseModel,
-)
+from flask_ml.flask_ml_server.models import (ErrorResponseModel, RequestModel,
+                                             ResponseModel)
 
 UNKNOWN_ERROR = "Unknown error. Please refer to the status field."
 

--- a/src/flask_ml/flask_ml_client/MLClient.py
+++ b/src/flask_ml/flask_ml_client/MLClient.py
@@ -2,8 +2,11 @@ from typing import Any, Union
 
 import requests
 
-from flask_ml.flask_ml_server.models import (ErrorResponseModel, RequestModel,
-                                             ResponseModel)
+from flask_ml.flask_ml_server.models import (
+    ErrorResponseModel,
+    RequestModel,
+    ResponseModel,
+)
 
 UNKNOWN_ERROR = "Unknown error. Please refer to the status field."
 

--- a/src/flask_ml/flask_ml_server/MLServer.py
+++ b/src/flask_ml/flask_ml_server/MLServer.py
@@ -1,9 +1,11 @@
-from flask import Flask, request, jsonify
-from pydantic import ValidationError, BaseModel
+import inspect
+from typing import get_args, get_origin, get_type_hints
+
+from flask import Flask, jsonify, request
+from pydantic import BaseModel, ValidationError
 
 from .models import ErrorResponseModel, RequestModel
-import inspect
-from typing import get_type_hints, get_origin, get_args
+
 
 def get_first_param_name(func):
     sig = inspect.signature(func)
@@ -12,11 +14,10 @@ def get_first_param_name(func):
         return None
     return next(iter(params)).name
 
+
 def format_schema_output(input_schema, output_schema):
-    return {
-        "inputs": input_schema,
-        "output": output_schema
-    }
+    return {"inputs": input_schema, "output": output_schema}
+
 
 def get_function_schema(fn):
     first_param_name = get_first_param_name(fn)
@@ -30,23 +31,19 @@ def get_function_schema(fn):
             return format_schema_output(None, None)
         inner_type = list_args[0]
         if issubclass(inner_type, BaseModel):
-            input_schema = {
-                "type": "array",
-                "items": inner_type.model_json_schema()
-            }
+            input_schema = {"type": "array", "items": inner_type.model_json_schema()}
         else:
             input_schema = None
     else:
         input_schema = None
 
-    output_model = type_hints.get('return')
+    output_model = type_hints.get("return")
     if output_model and issubclass(output_model, BaseModel):
         output_schema = output_model.model_json_schema()
     else:
         output_schema = None
 
     return format_schema_output(input_schema, output_schema)
-
 
 
 class MLServer(object):
@@ -70,10 +67,14 @@ class MLServer(object):
             """
             routes = []
             for rule in self.app.url_map.iter_rules():
-                schema = None if rule.rule not in self.endpoint2function else get_function_schema(self.endpoint2function[rule.rule])
+                schema = (
+                    None
+                    if rule.rule not in self.endpoint2function
+                    else get_function_schema(self.endpoint2function[rule.rule])
+                )
                 route_info = {
                     "rule": rule.rule,
-                    "methods": list(rule.methods - {'HEAD', 'OPTIONS'}),
+                    "methods": list(rule.methods - {"HEAD", "OPTIONS"}),
                     "schema": schema,
                 }
                 routes.append(route_info)
@@ -93,6 +94,7 @@ class MLServer(object):
 
         def build_route(ml_function):
             self.endpoint2function[rule] = ml_function
+
             @self.app.route(rule, endpoint=ml_function.__name__, methods=["POST"])
             def wrapper():
                 try:
@@ -109,7 +111,9 @@ class MLServer(object):
                         }
                         for err in error_details
                     ]
-                    return ErrorResponseModel(status="VALIDATION_ERROR", errors=error_details).get_response()
+                    return ErrorResponseModel(
+                        status="VALIDATION_ERROR", errors=error_details
+                    ).get_response()
 
             return wrapper
 

--- a/src/flask_ml/flask_ml_server/MLServer.py
+++ b/src/flask_ml/flask_ml_server/MLServer.py
@@ -1,8 +1,9 @@
 from flask import Flask, request, jsonify
-from pydantic import ValidationError
+from pydantic import ValidationError, BaseModel
 
 from .models import ErrorResponseModel, RequestModel
-from typing import get_type_hints, List, get_origin, get_args
+import inspect
+from typing import get_type_hints, get_origin, get_args
 
 def get_first_param_name(func):
     sig = inspect.signature(func)

--- a/src/flask_ml/flask_ml_server/MLServer.py
+++ b/src/flask_ml/flask_ml_server/MLServer.py
@@ -2,6 +2,50 @@ from flask import Flask, request, jsonify
 from pydantic import ValidationError
 
 from .models import ErrorResponseModel, RequestModel
+from typing import get_type_hints, List, get_origin, get_args
+
+def get_first_param_name(func):
+    sig = inspect.signature(func)
+    params = sig.parameters.values()
+    if len(params) == 0:
+        return None
+    return next(iter(params)).name
+
+def format_schema_output(input_schema, output_schema):
+    return {
+        "inputs": input_schema,
+        "output": output_schema
+    }
+
+def get_function_schema(fn):
+    first_param_name = get_first_param_name(fn)
+    if not first_param_name:
+        return format_schema_output(None, None)
+    type_hints = get_type_hints(fn)
+    input_type = type_hints.get(first_param_name)
+    if get_origin(input_type) is list:
+        list_args = get_args(input_type)
+        if len(list_args) == 0:
+            return format_schema_output(None, None)
+        inner_type = list_args[0]
+        if issubclass(inner_type, BaseModel):
+            input_schema = {
+                "type": "array",
+                "items": inner_type.model_json_schema()
+            }
+        else:
+            input_schema = None
+    else:
+        input_schema = None
+
+    output_model = type_hints.get('return')
+    if output_model and issubclass(output_model, BaseModel):
+        output_schema = output_model.model_json_schema()
+    else:
+        output_schema = None
+
+    return format_schema_output(input_schema, output_schema)
+
 
 
 class MLServer(object):
@@ -16,6 +60,7 @@ class MLServer(object):
         Instantiates the MLServer object as a wrapper for the Flask app.
         """
         self.app = Flask(name, static_folder=None)
+        self.endpoint2function = {}
 
         @self.app.route("/api/routes", methods=["GET"])
         def list_routes():
@@ -24,7 +69,12 @@ class MLServer(object):
             """
             routes = []
             for rule in self.app.url_map.iter_rules():
-                route_info = {"rule": rule.rule, "methods": list(rule.methods - {'HEAD', 'OPTIONS'})}
+                schema = None if rule.rule not in self.endpoint2function else get_function_schema(self.endpoint2function[rule.rule])
+                route_info = {
+                    "rule": rule.rule,
+                    "methods": list(rule.methods - {'HEAD', 'OPTIONS'}),
+                    "schema": schema,
+                }
                 routes.append(route_info)
             return jsonify(routes)
 
@@ -41,6 +91,7 @@ class MLServer(object):
             raise ValueError('The parameter "rule" is expected to be a string')
 
         def build_route(ml_function):
+            self.endpoint2function[rule] = ml_function
             @self.app.route(rule, endpoint=ml_function.__name__, methods=["POST"])
             def wrapper():
                 try:

--- a/src/flask_ml/flask_ml_server/MLServer.py
+++ b/src/flask_ml/flask_ml_server/MLServer.py
@@ -4,7 +4,7 @@ from typing import get_args, get_origin, get_type_hints
 from flask import Flask, jsonify, request
 from pydantic import BaseModel, ValidationError
 
-from .models import ErrorResponseModel, RequestModel
+from .models import ErrorResponseModel, RequestModel, ResponseModel
 
 
 def get_first_param_name(func):
@@ -100,7 +100,9 @@ class MLServer(object):
                 try:
                     data = request.get_json()
                     data = RequestModel(**data)
-                    return ml_function(data.inputs, data.parameters)
+                    result = ml_function(data.inputs, data.parameters)
+                    response = ResponseModel(status="SUCCESS", results=result)
+                    return response.get_response()
                 except ValidationError as e:
                     error_details = e.errors()
                     error_details = [

--- a/src/flask_ml/flask_ml_server/models.py
+++ b/src/flask_ml/flask_ml_server/models.py
@@ -13,7 +13,9 @@ class TextInput(MLInput):
 
 
 class FileInput(MLInput):
-    file_path: str = Field(..., description="Path of the file to be processed", min_length=1)
+    file_path: str = Field(
+        ..., description="Path of the file to be processed", min_length=1
+    )
 
 
 class CustomInput(MLInput):
@@ -45,12 +47,16 @@ class RequestModel(BaseModel):
         description="Type of the data, should be TEXT, IMAGE, VIDEO, AUDIO, or CUSTOM",
         min_length=1,
     )
-    parameters: Dict = Field(default_factory=dict, description="Additional parameters for the ML model")
+    parameters: Dict = Field(
+        default_factory=dict, description="Additional parameters for the ML model"
+    )
 
     @field_validator("data_type", mode="before")
     def check_data_type(cls, v):
         if v not in {"TEXT", "IMAGE", "VIDEO", "AUDIO", "CUSTOM"}:
-            raise ValueError("data_type must be one of TEXT, IMAGE, VIDEO, AUDIO, or CUSTOM")
+            raise ValueError(
+                "data_type must be one of TEXT, IMAGE, VIDEO, AUDIO, or CUSTOM"
+            )
         return v
 
     @model_validator(mode="before")
@@ -60,13 +66,19 @@ class RequestModel(BaseModel):
 
         if data_type == "TEXT":
             if not all(isinstance(item.get("text"), str) for item in inputs):
-                raise ValueError("All inputs must contain 'text' when data_type is TEXT")
+                raise ValueError(
+                    "All inputs must contain 'text' when data_type is TEXT"
+                )
         elif data_type in ["IMAGE", "VIDEO", "AUDIO"]:
             if not all(isinstance(item.get("file_path"), str) for item in inputs):
-                raise ValueError(f"All inputs must contain 'file_path' when data_type is {data_type}")
+                raise ValueError(
+                    f"All inputs must contain 'file_path' when data_type is {data_type}"
+                )
         elif data_type == "CUSTOM":
             if not all("input" in item for item in inputs):
-                raise ValueError("All inputs must contain 'input' when data_type is CUSTOM")
+                raise ValueError(
+                    "All inputs must contain 'input' when data_type is CUSTOM"
+                )
         return values
 
 
@@ -79,7 +91,9 @@ class MLResult(BaseModel):
 
 
 class FileResult(MLResult):
-    file_path: str = Field(..., description="Path of the file associated with the result", min_length=1)
+    file_path: str = Field(
+        ..., description="Path of the file associated with the result", min_length=1
+    )
 
 
 class ImageResult(FileResult):
@@ -95,7 +109,9 @@ class AudioResult(FileResult):
 
 
 class TextResult(MLResult):
-    text: str = Field(..., description="The text content associated with the result", min_length=1)
+    text: str = Field(
+        ..., description="The text content associated with the result", min_length=1
+    )
 
 
 class ResponseModel(BaseModel):

--- a/src/flask_ml/flask_ml_server/models.py
+++ b/src/flask_ml/flask_ml_server/models.py
@@ -114,7 +114,23 @@ class TextResult(MLResult):
     )
 
 
-class ResponseModel(BaseModel):
+class BaseResponseModel(BaseModel):
+    """
+    Base model for response models.
+    Methods:
+        model_dump_json() -> str:
+            Returns the JSON representation of the model.
+    """
+
+    def get_response(self, status_code: int = 200):
+        return Response(
+            response=self.model_dump_json(),
+            status=status_code,
+            mimetype="application/json",
+        )
+
+
+class ResponseModel(BaseResponseModel):
     """
     Model representing the results from an ML model.
     Attributes:
@@ -136,15 +152,8 @@ class ResponseModel(BaseModel):
         min_length=1,
     )
 
-    def get_response(self, status_code: int = 200):
-        return Response(
-            response=self.model_dump_json(),
-            status=status_code,
-            mimetype="application/json",
-        )
 
-
-class ErrorResponseModel(BaseModel):
+class ErrorResponseModel(BaseResponseModel):
     """
     Model representing an error response.
     Attributes:
@@ -163,8 +172,4 @@ class ErrorResponseModel(BaseModel):
     errors: List = Field(..., description="Details about the error that occurred")
 
     def get_response(self, status_code: int = 400):
-        return Response(
-            response=self.model_dump_json(),
-            status=status_code,
-            mimetype="application/json",
-        )
+        return super().get_response(status_code)

--- a/src/flask_ml/flask_ml_server/models.py
+++ b/src/flask_ml/flask_ml_server/models.py
@@ -83,17 +83,11 @@ class RequestModel(BaseModel):
 
 
 class MLResult(BaseModel):
-    result: Any = Field(
-        ...,
-        description="The result, which can be any JSON-serializable object",
-        min_length=1,
-    )
+    id: str = Field(..., description="The ID of the result", min_length=1)
 
 
 class FileResult(MLResult):
-    file_path: str = Field(
-        ..., description="Path of the file associated with the result", min_length=1
-    )
+    result: str = Field(..., description="Path of the result file.", min_length=1)
 
 
 class ImageResult(FileResult):
@@ -109,8 +103,30 @@ class AudioResult(FileResult):
 
 
 class TextResult(MLResult):
-    text: str = Field(
-        ..., description="The text content associated with the result", min_length=1
+    result: str = Field(..., description="The result text.", min_length=1)
+
+
+class BatchTextResult(BaseModel):
+    results: List[TextResult] = Field(
+        ..., description="List of text results", min_length=1
+    )
+
+
+class BatchImageResult(BaseModel):
+    results: List[ImageResult] = Field(
+        ..., description="List of image results", min_length=1
+    )
+
+
+class BatchAudioResult(BaseModel):
+    results: List[AudioResult] = Field(
+        ..., description="List of audio results", min_length=1
+    )
+
+
+class BatchVideoResult(BaseModel):
+    results: List[VideoResult] = Field(
+        ..., description="List of video results", min_length=1
     )
 
 
@@ -146,10 +162,9 @@ class ResponseModel(BaseResponseModel):
         description="The status of the operation, e.g., 'SUCCESS'",
         min_length=1,
     )
-    results: Sequence[Union[TextResult, ImageResult, AudioResult, VideoResult]] = Field(
+    results: Union[BatchTextResult, BatchVideoResult, BatchAudioResult, BatchImageResult] = Field(
         ...,
-        description="List of results, each either a file or text with its result",
-        min_length=1,
+        description="List of results",
     )
 
 

--- a/src/flask_ml/flask_ml_server/models.py
+++ b/src/flask_ml/flask_ml_server/models.py
@@ -162,7 +162,9 @@ class ResponseModel(BaseResponseModel):
         description="The status of the operation, e.g., 'SUCCESS'",
         min_length=1,
     )
-    results: Union[BatchTextResult, BatchVideoResult, BatchAudioResult, BatchImageResult] = Field(
+    results: Union[
+        BatchTextResult, BatchVideoResult, BatchAudioResult, BatchImageResult
+    ] = Field(
         ...,
         description="List of results",
     )

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,0 +1,164 @@
+FILE_INPUT_SCHEMA = {
+    "items": {
+        "properties": {
+        "file_path": {
+            "description": "Path of the file to be processed",
+            "minLength": 1,
+            "title": "File Path",
+            "type": "string"
+        }
+        },
+        "required": [
+        "file_path"
+        ],
+        "title": "FileInput",
+        "type": "object"
+    },
+    "type": "array"
+}
+
+
+TEXT_INPUT_SCHEMA = {
+    "items": {
+        "properties": {
+        "text": {
+            "description": "Text to be processed",
+            "minLength": 1,
+            "title": "Text",
+            "type": "string"
+        }
+        },
+        "required": [
+        "text"
+        ],
+        "title": "TextInput",
+        "type": "object"
+    },
+    "type": "array"
+}
+
+RESPONSE_MODEL_OUTPUT_SCHEMA = {
+    "$defs": {
+        "AudioResult": {
+        "properties": {
+            "file_path": {
+            "description": "Path of the file associated with the result",
+            "minLength": 1,
+            "title": "File Path",
+            "type": "string"
+            },
+            "result": {
+            "description": "The result, which can be any JSON-serializable object",
+            "minLength": 1,
+            "title": "Result"
+            }
+        },
+        "required": [
+            "result",
+            "file_path"
+        ],
+        "title": "AudioResult",
+        "type": "object"
+        },
+        "ImageResult": {
+        "properties": {
+            "file_path": {
+            "description": "Path of the file associated with the result",
+            "minLength": 1,
+            "title": "File Path",
+            "type": "string"
+            },
+            "result": {
+            "description": "The result, which can be any JSON-serializable object",
+            "minLength": 1,
+            "title": "Result"
+            }
+        },
+        "required": [
+            "result",
+            "file_path"
+        ],
+        "title": "ImageResult",
+        "type": "object"
+        },
+        "TextResult": {
+        "properties": {
+            "result": {
+            "description": "The result, which can be any JSON-serializable object",
+            "minLength": 1,
+            "title": "Result"
+            },
+            "text": {
+            "description": "The text content associated with the result",
+            "minLength": 1,
+            "title": "Text",
+            "type": "string"
+            }
+        },
+        "required": [
+            "result",
+            "text"
+        ],
+        "title": "TextResult",
+        "type": "object"
+        },
+        "VideoResult": {
+        "properties": {
+            "file_path": {
+            "description": "Path of the file associated with the result",
+            "minLength": 1,
+            "title": "File Path",
+            "type": "string"
+            },
+            "result": {
+            "description": "The result, which can be any JSON-serializable object",
+            "minLength": 1,
+            "title": "Result"
+            }
+        },
+        "required": [
+            "result",
+            "file_path"
+        ],
+        "title": "VideoResult",
+        "type": "object"
+        }
+    },
+    "description": "Model representing the results from an ML model.\nAttributes:\n    status (str): The status of the operation, e.g., 'success'\n    results (List[MLResult]): List of results.\nMethods:\n    get_response(status_code: int = 200) -\u003E Response:\n        Returns a Flask Response object with the JSON representation of the model.",
+    "properties": {
+        "results": {
+        "description": "List of results, each either a file or text with its result",
+        "items": {
+            "anyOf": [
+            {
+                "$ref": "#/$defs/TextResult"
+            },
+            {
+                "$ref": "#/$defs/ImageResult"
+            },
+            {
+                "$ref": "#/$defs/AudioResult"
+            },
+            {
+                "$ref": "#/$defs/VideoResult"
+            }
+            ]
+        },
+        "minItems": 1,
+        "title": "Results",
+        "type": "array"
+        },
+        "status": {
+        "default": "SUCCESS",
+        "description": "The status of the operation, e.g., 'SUCCESS'",
+        "minLength": 1,
+        "title": "Status",
+        "type": "string"
+        }
+    },
+    "required": [
+        "results"
+    ],
+    "title": "ResponseModel",
+    "type": "object"
+}

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,125 +1,107 @@
 FILE_INPUT_SCHEMA = {
     "items": {
         "properties": {
-        "file_path": {
-            "description": "Path of the file to be processed",
-            "minLength": 1,
-            "title": "File Path",
-            "type": "string"
-        }
+            "file_path": {
+                "description": "Path of the file to be processed",
+                "minLength": 1,
+                "title": "File Path",
+                "type": "string",
+            }
         },
-        "required": [
-        "file_path"
-        ],
+        "required": ["file_path"],
         "title": "FileInput",
-        "type": "object"
+        "type": "object",
     },
-    "type": "array"
+    "type": "array",
 }
 
 
 TEXT_INPUT_SCHEMA = {
     "items": {
         "properties": {
-        "text": {
-            "description": "Text to be processed",
-            "minLength": 1,
-            "title": "Text",
-            "type": "string"
-        }
+            "text": {
+                "description": "Text to be processed",
+                "minLength": 1,
+                "title": "Text",
+                "type": "string",
+            }
         },
-        "required": [
-        "text"
-        ],
+        "required": ["text"],
         "title": "TextInput",
-        "type": "object"
+        "type": "object",
     },
-    "type": "array"
+    "type": "array",
 }
 
 BATCH_TEXT_RESPONSE_SCHEMA = {
     "$defs": {
         "TextResult": {
-        "properties": {
-            "id": {
-            "description": "The ID of the result",
-            "minLength": 1,
-            "title": "Id",
-            "type": "string"
+            "properties": {
+                "id": {
+                    "description": "The ID of the result",
+                    "minLength": 1,
+                    "title": "Id",
+                    "type": "string",
+                },
+                "result": {
+                    "description": "The result text.",
+                    "minLength": 1,
+                    "title": "Result",
+                    "type": "string",
+                },
             },
-            "result": {
-            "description": "The result text.",
-            "minLength": 1,
-            "title": "Result",
-            "type": "string"
-            }
-        },
-        "required": [
-            "id",
-            "result"
-        ],
-        "title": "TextResult",
-        "type": "object"
+            "required": ["id", "result"],
+            "title": "TextResult",
+            "type": "object",
         }
     },
     "properties": {
         "results": {
-        "description": "List of text results",
-        "items": {
-            "$ref": "#/$defs/TextResult"
-        },
-        "minItems": 1,
-        "title": "Results",
-        "type": "array"
+            "description": "List of text results",
+            "items": {"$ref": "#/$defs/TextResult"},
+            "minItems": 1,
+            "title": "Results",
+            "type": "array",
         }
     },
-    "required": [
-        "results"
-    ],
+    "required": ["results"],
     "title": "BatchTextResult",
-    "type": "object"
+    "type": "object",
 }
 
 
 BATCH_IMAGE_RESPONSE_SCHEMA = {
     "$defs": {
         "ImageResult": {
-        "properties": {
-            "id": {
-            "description": "The ID of the result",
-            "minLength": 1,
-            "title": "Id",
-            "type": "string"
+            "properties": {
+                "id": {
+                    "description": "The ID of the result",
+                    "minLength": 1,
+                    "title": "Id",
+                    "type": "string",
+                },
+                "result": {
+                    "description": "Path of the result file.",
+                    "minLength": 1,
+                    "title": "Result",
+                    "type": "string",
+                },
             },
-            "result": {
-            "description": "Path of the result file.",
-            "minLength": 1,
-            "title": "Result",
-            "type": "string"
-            }
-        },
-        "required": [
-            "id",
-            "result"
-        ],
-        "title": "ImageResult",
-        "type": "object"
+            "required": ["id", "result"],
+            "title": "ImageResult",
+            "type": "object",
         }
     },
     "properties": {
         "results": {
-        "description": "List of image results",
-        "items": {
-            "$ref": "#/$defs/ImageResult"
-        },
-        "minItems": 1,
-        "title": "Results",
-        "type": "array"
+            "description": "List of image results",
+            "items": {"$ref": "#/$defs/ImageResult"},
+            "minItems": 1,
+            "title": "Results",
+            "type": "array",
         }
     },
-    "required": [
-        "results"
-    ],
+    "required": ["results"],
     "title": "BatchImageResult",
-    "type": "object"
+    "type": "object",
 }

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -37,128 +37,89 @@ TEXT_INPUT_SCHEMA = {
     "type": "array"
 }
 
-RESPONSE_MODEL_OUTPUT_SCHEMA = {
+BATCH_TEXT_RESPONSE_SCHEMA = {
     "$defs": {
-        "AudioResult": {
-        "properties": {
-            "file_path": {
-            "description": "Path of the file associated with the result",
-            "minLength": 1,
-            "title": "File Path",
-            "type": "string"
-            },
-            "result": {
-            "description": "The result, which can be any JSON-serializable object",
-            "minLength": 1,
-            "title": "Result"
-            }
-        },
-        "required": [
-            "result",
-            "file_path"
-        ],
-        "title": "AudioResult",
-        "type": "object"
-        },
-        "ImageResult": {
-        "properties": {
-            "file_path": {
-            "description": "Path of the file associated with the result",
-            "minLength": 1,
-            "title": "File Path",
-            "type": "string"
-            },
-            "result": {
-            "description": "The result, which can be any JSON-serializable object",
-            "minLength": 1,
-            "title": "Result"
-            }
-        },
-        "required": [
-            "result",
-            "file_path"
-        ],
-        "title": "ImageResult",
-        "type": "object"
-        },
         "TextResult": {
         "properties": {
-            "result": {
-            "description": "The result, which can be any JSON-serializable object",
+            "id": {
+            "description": "The ID of the result",
             "minLength": 1,
-            "title": "Result"
+            "title": "Id",
+            "type": "string"
             },
-            "text": {
-            "description": "The text content associated with the result",
+            "result": {
+            "description": "The result text.",
             "minLength": 1,
-            "title": "Text",
+            "title": "Result",
             "type": "string"
             }
         },
         "required": [
-            "result",
-            "text"
+            "id",
+            "result"
         ],
         "title": "TextResult",
         "type": "object"
-        },
-        "VideoResult": {
-        "properties": {
-            "file_path": {
-            "description": "Path of the file associated with the result",
-            "minLength": 1,
-            "title": "File Path",
-            "type": "string"
-            },
-            "result": {
-            "description": "The result, which can be any JSON-serializable object",
-            "minLength": 1,
-            "title": "Result"
-            }
-        },
-        "required": [
-            "result",
-            "file_path"
-        ],
-        "title": "VideoResult",
-        "type": "object"
         }
     },
-    "description": "Model representing the results from an ML model.\nAttributes:\n    status (str): The status of the operation, e.g., 'success'\n    results (List[MLResult]): List of results.\nMethods:\n    get_response(status_code: int = 200) -\u003E Response:\n        Returns a Flask Response object with the JSON representation of the model.",
     "properties": {
         "results": {
-        "description": "List of results, each either a file or text with its result",
+        "description": "List of text results",
         "items": {
-            "anyOf": [
-            {
-                "$ref": "#/$defs/TextResult"
-            },
-            {
-                "$ref": "#/$defs/ImageResult"
-            },
-            {
-                "$ref": "#/$defs/AudioResult"
-            },
-            {
-                "$ref": "#/$defs/VideoResult"
-            }
-            ]
+            "$ref": "#/$defs/TextResult"
         },
         "minItems": 1,
         "title": "Results",
         "type": "array"
-        },
-        "status": {
-        "default": "SUCCESS",
-        "description": "The status of the operation, e.g., 'SUCCESS'",
-        "minLength": 1,
-        "title": "Status",
-        "type": "string"
         }
     },
     "required": [
         "results"
     ],
-    "title": "ResponseModel",
+    "title": "BatchTextResult",
+    "type": "object"
+}
+
+
+BATCH_IMAGE_RESPONSE_SCHEMA = {
+    "$defs": {
+        "ImageResult": {
+        "properties": {
+            "id": {
+            "description": "The ID of the result",
+            "minLength": 1,
+            "title": "Id",
+            "type": "string"
+            },
+            "result": {
+            "description": "Path of the result file.",
+            "minLength": 1,
+            "title": "Result",
+            "type": "string"
+            }
+        },
+        "required": [
+            "id",
+            "result"
+        ],
+        "title": "ImageResult",
+        "type": "object"
+        }
+    },
+    "properties": {
+        "results": {
+        "description": "List of image results",
+        "items": {
+            "$ref": "#/$defs/ImageResult"
+        },
+        "minItems": 1,
+        "title": "Results",
+        "type": "array"
+        }
+    },
+    "required": [
+        "results"
+    ],
+    "title": "BatchImageResult",
     "type": "object"
 }

--- a/tests/test_ml_server_and_client.py
+++ b/tests/test_ml_server_and_client.py
@@ -4,14 +4,9 @@ import pytest
 
 from flask_ml.flask_ml_client import MLClient
 from flask_ml.flask_ml_server import MLServer
-from flask_ml.flask_ml_server.models import (
-    AudioResult,
-    ImageResult,
-    RequestModel,
-    ResponseModel,
-    TextResult,
-    VideoResult,
-)
+from flask_ml.flask_ml_server.models import (AudioResult, ImageResult,
+                                             RequestModel, ResponseModel,
+                                             TextResult, VideoResult)
 
 
 def test_invalid_route_parameters():
@@ -23,7 +18,9 @@ def test_invalid_route_parameters():
     with pytest.raises(ValueError, match='The parameter "input_type" cannot be None'):
         server.route("/test", None)
 
-    with pytest.raises(ValueError, match='The parameter "rule" is expected to be a string'):
+    with pytest.raises(
+        ValueError, match='The parameter "rule" is expected to be a string'
+    ):
         server.route(123, "TEXT")
 
 
@@ -58,19 +55,28 @@ def process_text(inputs, parameters):
 
 
 def process_image(inputs, parameters):
-    results = [ImageResult(file_path=inp.file_path, result="processed_image.img") for inp in inputs]
+    results = [
+        ImageResult(file_path=inp.file_path, result="processed_image.img")
+        for inp in inputs
+    ]
     response_model = ResponseModel(status="success", results=results)
     return response_model.get_response()
 
 
 def process_video(inputs, parameters):
-    results = [VideoResult(file_path=inp.file_path, result="processed_video.mp4") for inp in inputs]
+    results = [
+        VideoResult(file_path=inp.file_path, result="processed_video.mp4")
+        for inp in inputs
+    ]
     response_model = ResponseModel(status="success", results=results)
     return response_model.get_response()
 
 
 def process_audio(inputs, parameters):
-    results = [AudioResult(file_path=inp.file_path, result="processed_audio.wav") for inp in inputs]
+    results = [
+        AudioResult(file_path=inp.file_path, result="processed_audio.wav")
+        for inp in inputs
+    ]
     response_model = ResponseModel(status="success", results=results)
     return response_model.get_response()
 
@@ -82,7 +88,8 @@ def process_custom_input(inputs, parameters):
     results = [
         TextResult(
             text=custom_input_data.input["text"],
-            result=custom_input_data.input["text"] + custom_input_data.input["file_path"],
+            result=custom_input_data.input["text"]
+            + custom_input_data.input["file_path"],
         )
         for custom_input_data in inputs
     ]
@@ -164,7 +171,9 @@ def test_valid_text_request(app):
 def test_valid_text_request_client(mock_post, client):
     data = {"inputs": [{"text": "Sample text"}], "data_type": "TEXT", "parameters": {}}
 
-    mock_post.return_value = mock_post_request("http://127.0.0.1:5000/process_text", json=data)
+    mock_post.return_value = mock_post_request(
+        "http://127.0.0.1:5000/process_text", json=data
+    )
     response = client.request(data["inputs"], data["data_type"], data["parameters"])
 
     assert response == [{"result": "processed_text.txt", "text": "Sample text"}]
@@ -197,7 +206,9 @@ def test_valid_image_request(app):
     assert response.status_code == 200
     assert response.json == {
         "status": "success",
-        "results": [{"file_path": "/path/to/image.jpg", "result": "processed_image.img"}],
+        "results": [
+            {"file_path": "/path/to/image.jpg", "result": "processed_image.img"}
+        ],
     }
 
 
@@ -209,10 +220,14 @@ def test_valid_image_request_client(mock_post, client):
         "parameters": {},
     }
 
-    mock_post.return_value = mock_post_request("http://127.0.0.1:5000/process_image", json=data)
+    mock_post.return_value = mock_post_request(
+        "http://127.0.0.1:5000/process_image", json=data
+    )
     response = client.request(data["inputs"], data["data_type"], data["parameters"])
 
-    assert response == [{"result": "processed_image.img", "file_path": "/path/to/image.jpg"}]
+    assert response == [
+        {"result": "processed_image.img", "file_path": "/path/to/image.jpg"}
+    ]
 
 
 def test_invalid_image_request(app):
@@ -243,7 +258,9 @@ def test_valid_video_request(app):
     assert response.status_code == 200
     assert response.json == {
         "status": "success",
-        "results": [{"file_path": "/path/to/video.mp4", "result": "processed_video.mp4"}],
+        "results": [
+            {"file_path": "/path/to/video.mp4", "result": "processed_video.mp4"}
+        ],
     }
 
 
@@ -275,7 +292,9 @@ def test_valid_audio_request(app):
     assert response.status_code == 200
     assert response.json == {
         "status": "success",
-        "results": [{"file_path": "/path/to/audio.wav", "result": "processed_audio.wav"}],
+        "results": [
+            {"file_path": "/path/to/audio.wav", "result": "processed_audio.wav"}
+        ],
     }
 
 
@@ -300,7 +319,12 @@ def test_valid_custom_input_request(app):
     data = {
         "inputs": [
             {"input": {"text": "Sample text", "file_path": "/path/to/file.txt"}},
-            {"input": {"text": "Another text", "file_path": "/path/to/another_file.txt"}},
+            {
+                "input": {
+                    "text": "Another text",
+                    "file_path": "/path/to/another_file.txt",
+                }
+            },
         ],
         "data_type": "CUSTOM",
         "parameters": {},

--- a/tests/test_ml_server_and_client.py
+++ b/tests/test_ml_server_and_client.py
@@ -298,9 +298,9 @@ def test_valid_video_request(app):
     assert response.status_code == 200
     assert response.json == {
         "status": "SUCCESS",
-        "results": {"results": [
-            {"id": "/path/to/video.mp4", "result": "processed_video.mp4"}
-        ]},
+        "results": {
+            "results": [{"id": "/path/to/video.mp4", "result": "processed_video.mp4"}]
+        },
     }
 
 
@@ -332,9 +332,9 @@ def test_valid_audio_request(app):
     assert response.status_code == 200
     assert response.json == {
         "status": "SUCCESS",
-        "results": {"results":[
-            {"id": "/path/to/audio.wav", "result": "processed_audio.wav"}
-        ]},
+        "results": {
+            "results": [{"id": "/path/to/audio.wav", "result": "processed_audio.wav"}]
+        },
     }
 
 
@@ -376,9 +376,12 @@ def test_valid_custom_input_request(app):
         "status": "SUCCESS",
         "results": {
             "results": [
-            {"id": "Sample text", "result": "Sample text/path/to/file.txt"},
-            {"id": "Another text", "result": "Another text/path/to/another_file.txt"},
-        ]
+                {"id": "Sample text", "result": "Sample text/path/to/file.txt"},
+                {
+                    "id": "Another text",
+                    "result": "Another text/path/to/another_file.txt",
+                },
+            ]
         },
     }
 

--- a/tests/test_ml_server_and_client.py
+++ b/tests/test_ml_server_and_client.py
@@ -1,11 +1,12 @@
+from typing import List
 from unittest.mock import patch
 
 import pytest
-from typing import List
 
 from flask_ml.flask_ml_client import MLClient
 from flask_ml.flask_ml_server import MLServer
 from flask_ml.flask_ml_server.models import *
+
 from .constants import *
 
 

--- a/tests/test_request_models.py
+++ b/tests/test_request_models.py
@@ -3,12 +3,8 @@ import unittest
 from pydantic import ValidationError
 
 from flask_ml.flask_ml_server.constants import DataTypes
-from flask_ml.flask_ml_server.models import (
-    CustomInput,
-    FileInput,
-    RequestModel,
-    TextInput,
-)
+from flask_ml.flask_ml_server.models import (CustomInput, FileInput,
+                                             RequestModel, TextInput)
 
 
 class TestFileInputModel(unittest.TestCase):

--- a/tests/test_request_models.py
+++ b/tests/test_request_models.py
@@ -3,12 +3,8 @@ import unittest
 from pydantic import ValidationError
 
 from flask_ml.flask_ml_server.constants import DataTypes
-from flask_ml.flask_ml_server.models import (
-    CustomInput,
-    FileInput,
-    RequestModel,
-    TextInput,
-)
+from flask_ml.flask_ml_server.models import (CustomInput, FileInput,
+                                             RequestModel, TextInput)
 
 
 class TestFileInputModel(unittest.TestCase):
@@ -75,7 +71,10 @@ class TestRequestModel(unittest.TestCase):
 
     def test_valid_request_with_custom_inputs(self):
         data = {
-            "inputs": [{"input": ["inp1", {"a": "b"}, 123]}, {"input": {"key": "value"}}],
+            "inputs": [
+                {"input": ["inp1", {"a": "b"}, 123]},
+                {"input": {"key": "value"}},
+            ],
             "data_type": DataTypes.CUSTOM,
             "parameters": {},
         }

--- a/tests/test_request_models.py
+++ b/tests/test_request_models.py
@@ -3,8 +3,12 @@ import unittest
 from pydantic import ValidationError
 
 from flask_ml.flask_ml_server.constants import DataTypes
-from flask_ml.flask_ml_server.models import (CustomInput, FileInput,
-                                             RequestModel, TextInput)
+from flask_ml.flask_ml_server.models import (
+    CustomInput,
+    FileInput,
+    RequestModel,
+    TextInput,
+)
 
 
 class TestFileInputModel(unittest.TestCase):

--- a/tests/test_response_models.py
+++ b/tests/test_response_models.py
@@ -2,111 +2,100 @@ import unittest
 
 from pydantic import ValidationError
 
-from flask_ml.flask_ml_server.models import (AudioResult, FileResult,
-                                             ImageResult, ResponseModel,
-                                             TextResult, VideoResult)
+from flask_ml.flask_ml_server.models import *
 
 
 class TestFileResultModel(unittest.TestCase):
     def test_valid_file_result(self):
-        data = {"file_path": "file1.txt", "result": "output_file1.txt"}
+        data = {"id": "file1.txt", "result": "output_file1.txt"}
         result = FileResult(**data)
-        self.assertEqual(result.file_path, "file1.txt")
+        self.assertEqual(result.id, "file1.txt")
         self.assertEqual(result.result, "output_file1.txt")
 
-    def test_invalid_file_result_missing_file_path(self):
+    def test_invalid_file_result_missing_id(self):
         data = {"result": "output_file1.txt"}
         with self.assertRaises(ValidationError):
             FileResult(**data)
 
-    def test_valid_file_result_with_complex_result(self):
+    def test_invalid_file_result_with_complex_result(self):
         data = {
-            "file_path": "file1.txt",
+            "id": "file1.txt",
             "result": {"key": "value", "nested": [1, 2, 3]},
         }
-        result = FileResult(**data)
-        self.assertIsInstance(result.result, dict)
-        self.assertEqual(result.result["key"], "value")
-        self.assertEqual(result.result["nested"], [1, 2, 3])
+        with self.assertRaises(ValidationError):
+            TextResult(**data)
 
 
 class TestTextResultModel(unittest.TestCase):
     def test_valid_text_result(self):
-        data = {"text": "This is the first text", "result": "output_file1.txt"}
+        data = {"id": "This is the first text", "result": "output_file1.txt"}
         result = TextResult(**data)
-        self.assertEqual(result.text, "This is the first text")
+        self.assertEqual(result.id, "This is the first text")
         self.assertEqual(result.result, "output_file1.txt")
 
-    def test_invalid_text_result_missing_text(self):
+    def test_invalid_text_result_missing_id(self):
         data = {"result": "output_file1.txt"}
         with self.assertRaises(ValidationError):
             TextResult(**data)
 
-    def test_valid_text_result_with_complex_result(self):
+    def test_invalid_text_result_with_complex_result(self):
         data = {
-            "text": "This is the first text",
+            "id": "This is the first text",
             "result": {"key": "value", "nested": [1, 2, 3]},
         }
-        result = TextResult(**data)
-        self.assertIsInstance(result.result, dict)
-        self.assertEqual(result.result["key"], "value")
-        self.assertEqual(result.result["nested"], [1, 2, 3])
+        with self.assertRaises(ValidationError):
+            TextResult(**data)
 
 
 class TestResponseModel(unittest.TestCase):
     def test_valid_response_with_file_results(self):
         data = {
             "status": "success",
-            "results": [
-                {"file_path": "file1.txt", "result": "output_file1.txt"},
-                {"file_path": "file2.txt", "result": "output_file2.txt"},
-            ],
+            "results": BatchImageResult(
+                results=[
+                    {"id": "file1.txt", "result": "output_file1.png"},
+                    {"id": "file2.txt", "result": "output_file2.png"},
+                ]
+            ),
         }
         response = ResponseModel(**data)
         self.assertEqual(response.status, "success")
-        self.assertEqual(len(response.results), 2)
-        self.assertIsInstance(response.results[0], FileResult)
-        self.assertEqual(response.results[0].file_path, "file1.txt")
+        self.assertEqual(len(response.results.results), 2)
+        self.assertIsInstance(response.results.results[0], ImageResult)
+        self.assertEqual(response.results.results[0].id, "file1.txt")
 
     def test_valid_response_with_text_results(self):
         data = {
             "status": "success",
-            "results": [
-                {"text": "This is the first text", "result": "output_file1.txt"},
-                {"text": "This is the second text", "result": "output_file2.txt"},
-            ],
+            "results": {
+                "results": [
+                    {"id": "This is the first text", "result": "output_file1.txt"},
+                    {"id": "This is the second text", "result": "output_file2.txt"},
+                ]
+            },
         }
         response = ResponseModel(**data)
         self.assertEqual(response.status, "success")
-        self.assertEqual(len(response.results), 2)
-        self.assertIsInstance(response.results[0], TextResult)
-        self.assertEqual(response.results[0].text, "This is the first text")
-
-    def test_invalid_response_with_mixed_result_types(self):
-        data = {
-            "status": "success",
-            "results": [
-                {"file_path": "file1.txt", "result": "output_file1.txt"},
-                {"text": "This is the second text", "result": "output_file2.txt"},
-            ],
-        }
-        response = ResponseModel(**data)
-        self.assertEqual(len(response.results), 2)
-        self.assertIsInstance(response.results[0], FileResult)
-        self.assertIsInstance(response.results[1], TextResult)
+        self.assertEqual(len(response.results.results), 2)
+        self.assertIsInstance(response.results.results[0], TextResult)
+        self.assertEqual(response.results.results[0].id, "This is the first text")
 
     def test_valid_response_with_missing_status(self):
-        data = {"results": [{"file_path": "file1.txt", "result": "output_file1.txt"}]}
+        data = {
+            "results": {"results": [{"id": "file1.txt", "result": "output_file1.txt"}]}
+        }
         response = ResponseModel(**data)
         self.assertEqual(response.status, "SUCCESS")
 
     def test_invalid_response_with_invalid_result_structure(self):
         data = {
             "status": "success",
-            "results": [
-                {"file_path": "file1.txt"},
-                {"text": "This is the second text"},
-            ],
+            "results": {
+                "results": [
+                    {"id": "file1.txt"},
+                    {"id": "This is the second text"},
+                ]
+            },
         }
         with self.assertRaises(ValidationError):
             ResponseModel(**data)
@@ -121,24 +110,26 @@ class TestResponseModel(unittest.TestCase):
     def test_get_response_success(self):
         response_model = ResponseModel(
             status="SUCCESS",
-            results=[
-                TextResult(result="Processed text", text="Sample text"),
-                ImageResult(result="Processed image", file_path="/path/to/image.png"),
-                AudioResult(result="Processed audio", file_path="/path/to/audio.mp3"),
-                VideoResult(result="Processed video", file_path="/path/to/video.mp4"),
-            ],
+            results=BatchTextResult(
+                results=[
+                    TextResult(result="Processed text", id="Sample text"),
+                    TextResult(result="Processed text2", id="Sample text2"),
+                ]
+            ),
         )
         response = response_model.get_response()
         assert response.status_code == 200
         assert response.mimetype == "application/json"
         response_data = response.get_json()
         assert response_data["status"] == "SUCCESS"
-        assert len(response_data["results"]) == 4
+        assert len(response_data["results"]["results"]) == 2
 
     def test_get_response_custom_status_code(self):
         response_model = ResponseModel(
             status="SUCCESS",
-            results=[TextResult(result="Processed text", text="Sample text")],
+            results=BatchTextResult(
+                results=[TextResult(result="Processed text", id="Sample text")]
+            ),
         )
         response = response_model.get_response(status_code=201)
         assert response.status_code == 201

--- a/tests/test_response_models.py
+++ b/tests/test_response_models.py
@@ -2,14 +2,9 @@ import unittest
 
 from pydantic import ValidationError
 
-from flask_ml.flask_ml_server.models import (
-    AudioResult,
-    FileResult,
-    ImageResult,
-    ResponseModel,
-    TextResult,
-    VideoResult,
-)
+from flask_ml.flask_ml_server.models import (AudioResult, FileResult,
+                                             ImageResult, ResponseModel,
+                                             TextResult, VideoResult)
 
 
 class TestFileResultModel(unittest.TestCase):


### PR DESCRIPTION
Added support to return the input and output schema of an ml function through the "/api/routes" endpoint. The schema is infered using the type annotations.