### PR TITLE
Relax file path restrictions

### DIFF
--- a/src/flask_ml/flask_ml_cli/MLCli.py
+++ b/src/flask_ml/flask_ml_cli/MLCli.py
@@ -6,7 +6,7 @@ from typing_extensions import assert_never
 from flask_ml.flask_ml_cli.utils import (
     get_float_range_check_func_arg_parser,
     get_int_range_check_func_arg_parser,
-    is_path_exists_or_creatable_portable_arg_parser,
+    is_pathname_valid_arg_parser,
 )
 from flask_ml.flask_ml_server import MLServer
 from flask_ml.flask_ml_server.MLServer import EndpointDetails
@@ -42,19 +42,19 @@ from flask_ml.flask_ml_server.models import (
 def get_input_argument_validator_func(input_type: InputType):
     match input_type:
         case InputType.FILE:
-            return is_path_exists_or_creatable_portable_arg_parser
+            return is_pathname_valid_arg_parser
         case InputType.DIRECTORY:
-            return is_path_exists_or_creatable_portable_arg_parser
+            return is_pathname_valid_arg_parser
         case InputType.TEXT:
             return str
         case InputType.TEXTAREA:
             return str
         case InputType.BATCHFILE:
-            return is_path_exists_or_creatable_portable_arg_parser
+            return is_pathname_valid_arg_parser
         case InputType.BATCHTEXT:
             return str
         case InputType.BATCHDIRECTORY:
-            return is_path_exists_or_creatable_portable_arg_parser
+            return is_pathname_valid_arg_parser
         case _:  # pragma: no cover
             assert_never(input_type)
 

--- a/src/flask_ml/flask_ml_cli/MLCli.py
+++ b/src/flask_ml/flask_ml_cli/MLCli.py
@@ -41,20 +41,10 @@ from flask_ml.flask_ml_server.models import (
 
 def get_input_argument_validator_func(input_type: InputType):
     match input_type:
-        case InputType.FILE:
+        case InputType.FILE | InputType.DIRECTORY | InputType.BATCHFILE | InputType.BATCHDIRECTORY:
             return is_pathname_valid_arg_parser
-        case InputType.DIRECTORY:
-            return is_pathname_valid_arg_parser
-        case InputType.TEXT:
+        case InputType.TEXT | InputType.BATCHTEXT | InputType.TEXTAREA:
             return str
-        case InputType.TEXTAREA:
-            return str
-        case InputType.BATCHFILE:
-            return is_pathname_valid_arg_parser
-        case InputType.BATCHTEXT:
-            return str
-        case InputType.BATCHDIRECTORY:
-            return is_pathname_valid_arg_parser
         case _:  # pragma: no cover
             assert_never(input_type)
 

--- a/src/flask_ml/flask_ml_cli/utils.py
+++ b/src/flask_ml/flask_ml_cli/utils.py
@@ -139,6 +139,12 @@ def is_path_exists_or_creatable_portable_arg_parser(path: str) -> str:
     else:
         raise ValueError(f"{path} is not a valid path")
 
+def is_pathname_valid_arg_parser(pathname: str) -> str:
+    if is_pathname_valid(pathname):
+        return pathname
+    else:
+        raise ValueError(f"{pathname} is not a valid pathname")
+
 def get_int_range_check_func_arg_parser(range: IntRangeDescriptor) -> Callable[[Any], int]:
     def check_func(value: Any) -> int:
         try:


### PR DESCRIPTION
Previously, the CLI did not accept paths like `./output/output.db` when the `output` directory did not exist. This relaxes that restriction.